### PR TITLE
Convert  phpUnit tests to Kahlan for UseAtmon class

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,4 +28,4 @@ jobs:
       - name: PHP CS fix
         run: vendor/bin/php-cs-fixer fix --dry-run -v --diff
       - name: PHP unit tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/kahlan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Earlier Releases]
 
 Releases up to and including v1.0.0 predate this changelog, but see the [README](README.md) for summary of functionality.
+
+## 2025-01-17
+
+### Added
+- Converted PHPUnit test to Kahlan.
+
+### Changed
+- Replace `WP_MOCK` with `allow()` and `expect()`, following Kahlan's idiomatic approach
+- Updated dependencies in `composer.json` to remove `phpunit/phpunit` and `10up/wp_mock`.
+- Update the CI workflow in `continuos-integrasion.yml` to support Kahlan testing.

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "library",
     "license": "MIT",
     "require-dev": {
-        "10up/wp_mock": "^0.1.1",
         "dxw/php-cs-fixer-config": "^2.1",
         "kahlan/kahlan": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "library",
     "license": "MIT",
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
         "10up/wp_mock": "^0.1.1",
         "dxw/php-cs-fixer-config": "^2.1",
         "kahlan/kahlan": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "10up/wp_mock": "^0.1.1",
-        "dxw/php-cs-fixer-config": "^2.1"
+        "dxw/php-cs-fixer-config": "^2.1",
+        "kahlan/kahlan": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -6,9 +6,7 @@ describe('UseAtom', function () {
 	// initialisation
 	beforeEach(function () {
 		$this->useAtom = new \Dxw\Iguana\Extras\UseAtom();
-
-        allow('add_filter')->toBeCalled();
-        allow('remove_action')->toBeCalled();
+        
         allow('add_action')->toBeCalled();
 	});
 
@@ -28,17 +26,20 @@ describe('UseAtom', function () {
 	});
 
 	describe('::init()', function () {
-		it('adds the default_feed filter correctly', function () {
-			allow('add_action')->toBeCalled();
-			expect('add_filter')->toBeCalled()->once()->with('default_feed', [$this->useAtom, 'defaultFeed']);
+		it('adds the default_feed filter and removes actions correctly', function () {
+			allow('add_filter')->toBeCalled();
+            allow('remove_action')->toBeCalled();
 
-			allow('remove_action')->toBeCalled();
+
+            // Assertions
+			expect('add_filter')->toBeCalled()->once()->with('default_feed', [$this->useAtom, 'defaultFeed']);
 			expect('remove_action')->toBeCalled()->times(3);
 			expect('remove_action')->toBeCalled()->with('do_feed_rdf', 'do_feed_rdf', 10, 1);
-			allow('remove_action')->toBeCalled()->with('do_feed_rss', 'do_feed_rss', 10, 1);
-			allow('remove_action')->toBeCalled()->with('do_feed_rss2', 'do_feed_rss2', 10, 1);
+			expect('remove_action')->toBeCalled()->with('do_feed_rss', 'do_feed_rss', 10, 1);
+			expect('remove_action')->toBeCalled()->with('do_feed_rss2', 'do_feed_rss2', 10, 1);
 
-			$this->useAtom->init();
+            $this->useAtom->init();
+			
 		});
 
 
@@ -75,8 +76,7 @@ describe('UseAtom', function () {
 			$this->useAtom->wpHead();
 			$results = ob_get_clean();
 
-			// expect($results)->toBeA('string');
-			// expect(false)->toBeA('boolean');
+
 			expect($results)->toBe('        <link rel="alternate" type="application/atom+xml" title="_Xyz_ Feed" href="_xyz_">'."\n        ");
 		});
 	});

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -6,15 +6,19 @@ describe('UseAtom', function () {
 	// initialisation
 	beforeEach(function () {
 		$this->useAtom = new \Dxw\Iguana\Extras\UseAtom();
-        
-        allow('add_action')->toBeCalled();
+
 	});
 
 	afterEach(function () {
-        unset($this->useAtom);
+		unset($this->useAtom);
 	});
 
 	describe("::register()", function () {
+		it('implement the registerable interface', function () {
+			expect($this->useAtom)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class, $this->useAtom);
+		});
+
+
 		it('should register actions correctly', function () {
 			allow('add_action')->toBeCalled();
 			expect('add_action')->toBeCalled()->times(2);
@@ -28,26 +32,26 @@ describe('UseAtom', function () {
 	describe('::init()', function () {
 		it('adds the default_feed filter and removes actions correctly', function () {
 			allow('add_filter')->toBeCalled();
-            allow('remove_action')->toBeCalled();
+			allow('remove_action')->toBeCalled();
 
 
-            // Assertions
+			// Assertions
 			expect('add_filter')->toBeCalled()->once()->with('default_feed', [$this->useAtom, 'defaultFeed']);
 			expect('remove_action')->toBeCalled()->times(3);
 			expect('remove_action')->toBeCalled()->with('do_feed_rdf', 'do_feed_rdf', 10, 1);
 			expect('remove_action')->toBeCalled()->with('do_feed_rss', 'do_feed_rss', 10, 1);
 			expect('remove_action')->toBeCalled()->with('do_feed_rss2', 'do_feed_rss2', 10, 1);
 
-            $this->useAtom->init();
-			
+			$this->useAtom->init();
+
 		});
 
 
 
 		// Check that this code runs to completion without errors
 		it('completes execution without errors', function () {
-            allow('add_filter')->toBeCalled();
-            allow('remove_action')->toBeCalled();
+			allow('add_filter')->toBeCalled();
+			allow('remove_action')->toBeCalled();
 
 			expect(function () {
 				$this->useAtom->init();
@@ -65,7 +69,6 @@ describe('UseAtom', function () {
 			allow('esc_attr')->toBeCalled()->andRun(function ($a) {
 				return '_'.$a.'_';
 			});
-			expect('esc_attr')->toBeCalled()->with('xyz');
 
 
 			allow('get_feed_link')->toBeCalled()->andReturn('xyz');

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -2,64 +2,82 @@
 
 use Dxw\Iguana\Extras\UseAtom;
 
-describe('UseAtom', function() {
-    // initialisation
-    beforeEach(function () {
-        $this->useAtom = new \Dxw\Iguana\Extras\UseAtom();
-        \WP_Mock::setUp();
-    });
+describe('UseAtom', function () {
+	// initialisation
+	beforeEach(function () {
+		$this->useAtom = new \Dxw\Iguana\Extras\UseAtom();
 
-    afterEach(function() {
-        \WP_Mock::tearDown();
-    });
+        allow('add_filter')->toBeCalled();
+        allow('remove_action')->toBeCalled();
+        allow('add_action')->toBeCalled();
+	});
 
-    describe("::register()", function() {
-        it('should register actions correctly', function() {
-            allow('add_action')->tobeCalled()->with('init', [$this->useAtom, 'init']);
-            allow('add_action')->tobeCalled()->with('wp_head', [$this->useAtom, 'wpHead']);
+	afterEach(function () {
+        unset($this->useAtom);
+	});
 
-    
-            
-            $this->useAtom->register();           
-        });
-    });
+	describe("::register()", function () {
+		it('should register actions correctly', function () {
+			allow('add_action')->toBeCalled();
+			expect('add_action')->toBeCalled()->times(2);
+			expect('add_action')->toBeCalled()->once()->with('init', [$this->useAtom, 'init']);
+			expect('add_action')->toBeCalled()->once()->with('wp_head', [$this->useAtom, 'wpHead']);
 
-    describe('::init()', function() {
-        it('adds the default_feed filter correctly', function() {
-            allow('add_filter')->tobeCalled()->with('default_feed',[$this->useAtom, 'defaultFeed']);
-            allow('remove_action')->tobeCalled()->with('do_feed_rdf', 'do_feed_rdf', 10, 1);
-            allow('remove_action')->tobeCalled()->with('do_feed_rss', 'do_feed_rss', 10, 1);
-            allow('remove_action')->tobeCalled()->with('do_feed_rss2', 'do_feed_rss2', 10, 1);
+			$this->useAtom->register();
+		});
+	});
 
-            $this->useAtom->init();
-        });
+	describe('::init()', function () {
+		it('adds the default_feed filter correctly', function () {
+			allow('add_action')->toBeCalled();
+			expect('add_filter')->toBeCalled()->once()->with('default_feed', [$this->useAtom, 'defaultFeed']);
 
-    
+			allow('remove_action')->toBeCalled();
+			expect('remove_action')->toBeCalled()->times(3);
+			expect('remove_action')->toBeCalled()->with('do_feed_rdf', 'do_feed_rdf', 10, 1);
+			allow('remove_action')->toBeCalled()->with('do_feed_rss', 'do_feed_rss', 10, 1);
+			allow('remove_action')->toBeCalled()->with('do_feed_rss2', 'do_feed_rss2', 10, 1);
 
-        // Check that this code runs to completion without errors
-        it('completes execution without errors', function() {
-            expect(function () {
-                $this->useAtom->init();
-            })->not->toThrow();            
-        });
-    });
+			$this->useAtom->init();
+		});
 
-    describe('::wpHead()', function() {
-        it('outputs the correct link in wp_head', function() {
-            allow('get_bloginfo')->toBeCalled()->andReturn('Xyz');
-            allow('esc_attr')->toBeCalled()->andRun(function ($a) {
-                return '_'.$a.'_';
-            });
-            allow('get_feed_link')->toBeCalled()->with('atom')->andReturn('xyz');
 
-           
-            ob_start();
-            $results = $this->useAtom->wpHead();
-            $results = ob_get_clean();
 
-            expect($results)->toBeA('string');
-            expect(false)->toBeA('boolean');
-            expect($results)->toBe('        <link rel="alternate" type="application/atom+xml" title="_Xyz_ Feed" href="_xyz_">'."\n        ");
-        });
-    });
+		// Check that this code runs to completion without errors
+		it('completes execution without errors', function () {
+            allow('add_filter')->toBeCalled();
+            allow('remove_action')->toBeCalled();
+
+			expect(function () {
+				$this->useAtom->init();
+			})->not->toThrow();
+		});
+	});
+
+	describe('::wpHead()', function () {
+		it('outputs the correct link in wp_head', function () {
+			allow('get_bloginfo')->toBeCalled()->andReturn('Xyz');
+			expect('get_bloginfo')->toBeCalled()->once()->with('name');
+
+
+
+			allow('esc_attr')->toBeCalled()->andRun(function ($a) {
+				return '_'.$a.'_';
+			});
+			expect('esc_attr')->toBeCalled()->with('xyz');
+
+
+			allow('get_feed_link')->toBeCalled()->andReturn('xyz');
+			expect('get_feed_link')->toBeCalled()->once()->with('atom');
+
+
+			ob_start();
+			$this->useAtom->wpHead();
+			$results = ob_get_clean();
+
+			// expect($results)->toBeA('string');
+			// expect(false)->toBeA('boolean');
+			expect($results)->toBe('        <link rel="alternate" type="application/atom+xml" title="_Xyz_ Feed" href="_xyz_">'."\n        ");
+		});
+	});
 });

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -1,0 +1,26 @@
+<?php
+
+use Dxw\Iguana\Extras\UseAtom;
+
+
+describe('UseAtom', function() {
+    // initialisation
+    beforeEach(function () {
+        $this->useAtom = new \Dxw\Iguana\Extras\UseAtom();
+        \WP_Mock::setUp();
+    });
+
+    afterEach(function() {
+        \WP_Mock::tearDown();
+    });
+
+    it('should register actions correctly', function() {
+        // expect($this->UseAtom)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+        \WP_Mock::expectActionAdded('init', [$this->useAtom, 'init']);
+        \WP_Mock::expectActionAdded('wp_head', [$this->useAtom, 'wpHead']);
+
+        $this->useAtom->register();
+        
+    });
+});
+

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -2,7 +2,6 @@
 
 use Dxw\Iguana\Extras\UseAtom;
 
-
 describe('UseAtom', function() {
     // initialisation
     beforeEach(function () {
@@ -16,24 +15,18 @@ describe('UseAtom', function() {
 
     describe("::register()", function() {
         it('should register actions correctly', function() {
-            // expect($this->UseAtom)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
             \WP_Mock::expectActionAdded('init', [$this->useAtom, 'init']);
             \WP_Mock::expectActionAdded('wp_head', [$this->useAtom, 'wpHead']);
     
+            
             $this->useAtom->register();           
         });
     });
 
     describe('::init()', function() {
-        
-        it('starts correclty by removing filters and actions', function() {
+        it('adds the default_feed filter correctly', function() {
             \WP_Mock::expectFilterAdded('default_feed', [$this->useAtom, 'defaultFeed']);
 
-            $this->useAtmon->init();
-        });
-
-        it("removes the actions", function() {
-            
             \WP_Mock::wpFunction('remove_action', [
                 'args' => ['do_feed_rdf', 'do_feed_rdf', 10, 1],
                 'times' => 1,
@@ -47,19 +40,62 @@ describe('UseAtom', function() {
                 'times' => 1,
             ]);
 
+            // Call init() method
             $this->useAtom->init();
         });
 
-        // Check that this code runs to completion.
+        it("removes the actions", function() {
+            \WP_Mock::wpFunction('remove_action', [
+                'args' => ['do_feed_rdf', 'do_feed_rdf', 10, 1],
+                'times' => 1,
+            ]);
+            \WP_Mock::wpFunction('remove_action', [
+                'args' => ['do_feed_rss', 'do_feed_rss', 10, 1],
+                'times' => 1,
+            ]);
+            \WP_Mock::wpFunction('remove_action', [
+                'args' => ['do_feed_rss2', 'do_feed_rss2', 10, 1],
+                'times' => 1,
+            ]);
+
+            // Call init() method
+            $this->useAtom->init();
+        });
+
+        // Check that this code runs to completion without errors
         it('completes execution without errors', function() {
-            expect(function() {
+            expect(function () {
                 $this->useAtom->init();
-            })->not->toThrow();
+            })->not->toThrow();            
         });
     });
 
+    describe('::wpHead()', function() {
+        it('outputs the correct link in wp_head', function() {
+            \WP_Mock::wpFunction('get_bloginfo', [
+                'args' => ['name'],
+                'return' => 'Xyz',
+            ]);
     
-
-
+            \WP_Mock::wpFunction('esc_attr', [
+                'return' => function ($a) {
+                    return '_'.$a.'_';
+                },
+            ]);
     
+            \WP_Mock::wpFunction('get_feed_link', [
+                'args' => ['atom'],
+                'return' => 'xyz',
+            ]);
+
+           
+            ob_start();
+            $results = $this->useAtom->wpHead();
+            $results = ob_get_clean();
+
+            expect($results)->toBeA('string');
+            expect(false)->toBeA('boolean');
+            expect($results)->toBe('        <link rel="alternate" type="application/atom+xml" title="_Xyz_ Feed" href="_xyz_">'."\n        ");
+        });
+    });
 });

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -14,13 +14,18 @@ describe('UseAtom', function() {
         \WP_Mock::tearDown();
     });
 
-    it('should register actions correctly', function() {
-        // expect($this->UseAtom)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
-        \WP_Mock::expectActionAdded('init', [$this->useAtom, 'init']);
-        \WP_Mock::expectActionAdded('wp_head', [$this->useAtom, 'wpHead']);
+    describe("::register()", function() {
+        it('should register actions correctly', function() {
+            // expect($this->UseAtom)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+            \WP_Mock::expectActionAdded('init', [$this->useAtom, 'init']);
+            \WP_Mock::expectActionAdded('wp_head', [$this->useAtom, 'wpHead']);
+    
+            $this->useAtom->register();
+            
+        });
 
-        $this->useAtom->register();
-        
     });
-});
 
+
+    
+});

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -15,8 +15,9 @@ describe('UseAtom', function() {
 
     describe("::register()", function() {
         it('should register actions correctly', function() {
-            \WP_Mock::expectActionAdded('init', [$this->useAtom, 'init']);
-            \WP_Mock::expectActionAdded('wp_head', [$this->useAtom, 'wpHead']);
+            allow('add_action')->tobeCalled()->with('init', [$this->useAtom, 'init']);
+            allow('add_action')->tobeCalled()->with('wp_head', [$this->useAtom, 'wpHead']);
+
     
             
             $this->useAtom->register();           
@@ -25,42 +26,15 @@ describe('UseAtom', function() {
 
     describe('::init()', function() {
         it('adds the default_feed filter correctly', function() {
-            \WP_Mock::expectFilterAdded('default_feed', [$this->useAtom, 'defaultFeed']);
+            allow('add_filter')->tobeCalled()->with('default_feed',[$this->useAtom, 'defaultFeed']);
+            allow('remove_action')->tobeCalled()->with('do_feed_rdf', 'do_feed_rdf', 10, 1);
+            allow('remove_action')->tobeCalled()->with('do_feed_rss', 'do_feed_rss', 10, 1);
+            allow('remove_action')->tobeCalled()->with('do_feed_rss2', 'do_feed_rss2', 10, 1);
 
-            \WP_Mock::wpFunction('remove_action', [
-                'args' => ['do_feed_rdf', 'do_feed_rdf', 10, 1],
-                'times' => 1,
-            ]);
-            \WP_Mock::wpFunction('remove_action', [
-                'args' => ['do_feed_rss', 'do_feed_rss', 10, 1],
-                'times' => 1,
-            ]);
-            \WP_Mock::wpFunction('remove_action', [
-                'args' => ['do_feed_rss2', 'do_feed_rss2', 10, 1],
-                'times' => 1,
-            ]);
-
-            // Call init() method
             $this->useAtom->init();
         });
 
-        it("removes the actions", function() {
-            \WP_Mock::wpFunction('remove_action', [
-                'args' => ['do_feed_rdf', 'do_feed_rdf', 10, 1],
-                'times' => 1,
-            ]);
-            \WP_Mock::wpFunction('remove_action', [
-                'args' => ['do_feed_rss', 'do_feed_rss', 10, 1],
-                'times' => 1,
-            ]);
-            \WP_Mock::wpFunction('remove_action', [
-                'args' => ['do_feed_rss2', 'do_feed_rss2', 10, 1],
-                'times' => 1,
-            ]);
-
-            // Call init() method
-            $this->useAtom->init();
-        });
+    
 
         // Check that this code runs to completion without errors
         it('completes execution without errors', function() {
@@ -72,21 +46,11 @@ describe('UseAtom', function() {
 
     describe('::wpHead()', function() {
         it('outputs the correct link in wp_head', function() {
-            \WP_Mock::wpFunction('get_bloginfo', [
-                'args' => ['name'],
-                'return' => 'Xyz',
-            ]);
-    
-            \WP_Mock::wpFunction('esc_attr', [
-                'return' => function ($a) {
-                    return '_'.$a.'_';
-                },
-            ]);
-    
-            \WP_Mock::wpFunction('get_feed_link', [
-                'args' => ['atom'],
-                'return' => 'xyz',
-            ]);
+            allow('get_bloginfo')->toBeCalled()->andReturn('Xyz');
+            allow('esc_attr')->toBeCalled()->andRun(function ($a) {
+                return '_'.$a.'_';
+            });
+            allow('get_feed_link')->toBeCalled()->with('atom')->andReturn('xyz');
 
            
             ob_start();

--- a/spec/UseAtomSpec.php
+++ b/spec/UseAtomSpec.php
@@ -20,11 +20,45 @@ describe('UseAtom', function() {
             \WP_Mock::expectActionAdded('init', [$this->useAtom, 'init']);
             \WP_Mock::expectActionAdded('wp_head', [$this->useAtom, 'wpHead']);
     
-            $this->useAtom->register();
-            
+            $this->useAtom->register();           
+        });
+    });
+
+    describe('::init()', function() {
+        
+        it('starts correclty by removing filters and actions', function() {
+            \WP_Mock::expectFilterAdded('default_feed', [$this->useAtom, 'defaultFeed']);
+
+            $this->useAtmon->init();
         });
 
+        it("removes the actions", function() {
+            
+            \WP_Mock::wpFunction('remove_action', [
+                'args' => ['do_feed_rdf', 'do_feed_rdf', 10, 1],
+                'times' => 1,
+            ]);
+            \WP_Mock::wpFunction('remove_action', [
+                'args' => ['do_feed_rss', 'do_feed_rss', 10, 1],
+                'times' => 1,
+            ]);
+            \WP_Mock::wpFunction('remove_action', [
+                'args' => ['do_feed_rss2', 'do_feed_rss2', 10, 1],
+                'times' => 1,
+            ]);
+
+            $this->useAtom->init();
+        });
+
+        // Check that this code runs to completion.
+        it('completes execution without errors', function() {
+            expect(function() {
+                $this->useAtom->init();
+            })->not->toThrow();
+        });
     });
+
+    
 
 
     

--- a/src/UseAtom.php
+++ b/src/UseAtom.php
@@ -18,11 +18,11 @@ class UseAtom implements \Dxw\Iguana\Registerable
 	{
 
 		add_filter('default_feed', [$this, 'defaultFeed']);
-	
+
 		remove_action('do_feed_rdf', 'do_feed_rdf', 10, 1);
 		remove_action('do_feed_rss', 'do_feed_rss', 10, 1);
 		remove_action('do_feed_rss2', 'do_feed_rss2', 10, 1);
-		
+
 	}
 
 	public function defaultFeed()

--- a/src/UseAtom.php
+++ b/src/UseAtom.php
@@ -17,10 +17,8 @@ class UseAtom implements \Dxw\Iguana\Registerable
 	public function init()
 	{
 
-		error_log('calling add_filter for default_feed');
 		add_filter('default_feed', [$this, 'defaultFeed']);
 	
-        error_log('Calling remove_action for feeds');
 		remove_action('do_feed_rdf', 'do_feed_rdf', 10, 1);
 		remove_action('do_feed_rss', 'do_feed_rss', 10, 1);
 		remove_action('do_feed_rss2', 'do_feed_rss2', 10, 1);

--- a/src/UseAtom.php
+++ b/src/UseAtom.php
@@ -16,11 +16,15 @@ class UseAtom implements \Dxw\Iguana\Registerable
 
 	public function init()
 	{
+
+		
 		add_filter('default_feed', [$this, 'defaultFeed']);
+	
 
 		remove_action('do_feed_rdf', 'do_feed_rdf', 10, 1);
 		remove_action('do_feed_rss', 'do_feed_rss', 10, 1);
 		remove_action('do_feed_rss2', 'do_feed_rss2', 10, 1);
+		
 	}
 
 	public function defaultFeed()

--- a/src/UseAtom.php
+++ b/src/UseAtom.php
@@ -17,10 +17,10 @@ class UseAtom implements \Dxw\Iguana\Registerable
 	public function init()
 	{
 
-		
+		error_log('calling add_filter for default_feed');
 		add_filter('default_feed', [$this, 'defaultFeed']);
 	
-
+        error_log('Calling remove_action for feeds');
 		remove_action('do_feed_rdf', 'do_feed_rdf', 10, 1);
 		remove_action('do_feed_rss', 'do_feed_rss', 10, 1);
 		remove_action('do_feed_rss2', 'do_feed_rss2', 10, 1);


### PR DESCRIPTION
This Pr converts the existing phpUnit tests from the UseAtom class to Kahlan. I followed the Kahlan documentation to structure the tests into clear sections using ```describe```, ```it``` , and ```beforeEach``` blocks.

Key changes:
- Implemented test for ```::registered()``` to verify that actions ```init``` and ```wp_head``` are registered with the correct callbacks using ```\WP_Mock```
- Converted test for ```::init()``` to manage filter and action
- Converted test for  ```::wpHead()``` to ensure correct ink generation
- I used```beforeEach``` and ```afterEach``` for setup and teardown.
- I used ```\WP_Mock``` in the same way as in the original phpUnit test file.
- Faced difficulties with ```expect($results)->toBe()``` syntax initially but I resolved by checking Kahlan matcher methods.
